### PR TITLE
Add SwiftUI wedding planner app

### DIFF
--- a/SwiftApp/Model/BudgetItem.swift
+++ b/SwiftApp/Model/BudgetItem.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+struct BudgetItem: Identifiable, Codable {
+    let id: UUID
+    var description: String
+    var cost: Double
+}

--- a/SwiftApp/Model/Guest.swift
+++ b/SwiftApp/Model/Guest.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+struct Guest: Identifiable, Codable {
+    let id: UUID
+    var name: String
+    var rsvp: Bool
+}

--- a/SwiftApp/Model/PlannerTask.swift
+++ b/SwiftApp/Model/PlannerTask.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+struct PlannerTask: Identifiable, Codable {
+    let id: UUID
+    var title: String
+    var isCompleted: Bool
+}

--- a/SwiftApp/Views/BudgetView.swift
+++ b/SwiftApp/Views/BudgetView.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+
+struct BudgetView: View {
+    @State private var items: [BudgetItem] = [
+        BudgetItem(id: UUID(), description: "Venue", cost: 2000),
+        BudgetItem(id: UUID(), description: "Catering", cost: 3500)
+    ]
+    @State private var newDescription = ""
+    @State private var newCost = ""
+
+    var totalCost: Double {
+        items.reduce(0.0) { $0 + $1.cost }
+    }
+
+    var body: some View {
+        VStack {
+            List {
+                ForEach(items) { item in
+                    HStack {
+                        Text(item.description)
+                        Spacer()
+                        Text("$\(item.cost, specifier: \"%.2f\")")
+                    }
+                }
+                .onDelete { indexSet in
+                    items.remove(atOffsets: indexSet)
+                }
+            }
+            HStack {
+                TextField("Description", text: $newDescription)
+                TextField("Cost", text: $newCost)
+                    .keyboardType(.decimalPad)
+                Button("Add") {
+                    guard let cost = Double(newCost), !newDescription.isEmpty else { return }
+                    items.append(BudgetItem(id: UUID(), description: newDescription, cost: cost))
+                    newDescription = ""
+                    newCost = ""
+                }
+            }
+            .padding()
+            Text("Total: $\(totalCost, specifier: \"%.2f\")")
+                .bold()
+                .padding(.top)
+        }
+        .navigationTitle("Budget")
+    }
+}

--- a/SwiftApp/Views/DashboardView.swift
+++ b/SwiftApp/Views/DashboardView.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+struct DashboardView: View {
+    var body: some View {
+        NavigationView {
+            List {
+                NavigationLink(destination: GuestListView()) {
+                    Label("Guest List", systemImage: "person.3")
+                }
+                NavigationLink(destination: TasksView()) {
+                    Label("Tasks", systemImage: "checkmark.circle")
+                }
+                NavigationLink(destination: BudgetView()) {
+                    Label("Budget", systemImage: "dollarsign.circle")
+                }
+            }
+            .navigationTitle("Wedding Planner")
+        }
+    }
+}

--- a/SwiftApp/Views/GuestListView.swift
+++ b/SwiftApp/Views/GuestListView.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+struct GuestListView: View {
+    @State private var guests: [Guest] = [
+        Guest(id: UUID(), name: "Alice", rsvp: true),
+        Guest(id: UUID(), name: "Bob", rsvp: false)
+    ]
+    @State private var newGuestName: String = ""
+
+    var body: some View {
+        VStack {
+            List {
+                ForEach(guests) { guest in
+                    HStack {
+                        Text(guest.name)
+                        Spacer()
+                        Image(systemName: guest.rsvp ? "checkmark.circle" : "xmark.circle")
+                            .foregroundColor(guest.rsvp ? .green : .red)
+                    }
+                }
+            }
+            HStack {
+                TextField("New Guest Name", text: $newGuestName)
+                Button("Add") {
+                    guard !newGuestName.isEmpty else { return }
+                    guests.append(Guest(id: UUID(), name: newGuestName, rsvp: false))
+                    newGuestName = ""
+                }
+            }
+            .padding()
+        }
+        .navigationTitle("Guest List")
+    }
+}

--- a/SwiftApp/Views/TasksView.swift
+++ b/SwiftApp/Views/TasksView.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+
+struct TasksView: View {
+    @State private var tasks: [PlannerTask] = [
+        PlannerTask(id: UUID(), title: "Book Venue", isCompleted: false),
+        PlannerTask(id: UUID(), title: "Send Invitations", isCompleted: false)
+    ]
+    @State private var newTaskTitle: String = ""
+
+    var body: some View {
+        VStack {
+            List {
+                ForEach($tasks) { $task in
+                    HStack {
+                        Text(task.title)
+                        Spacer()
+                        Button(action: { task.isCompleted.toggle() }) {
+                            Image(systemName: task.isCompleted ? "checkmark.square" : "square")
+                                .foregroundColor(task.isCompleted ? .green : .primary)
+                        }
+                    }
+                }
+                .onDelete { indexSet in
+                    tasks.remove(atOffsets: indexSet)
+                }
+            }
+            HStack {
+                TextField("New Task", text: $newTaskTitle)
+                Button("Add") {
+                    guard !newTaskTitle.isEmpty else { return }
+                    tasks.append(PlannerTask(id: UUID(), title: newTaskTitle, isCompleted: false))
+                    newTaskTitle = ""
+                }
+            }
+            .padding()
+        }
+        .navigationTitle("Tasks")
+    }
+}

--- a/SwiftApp/WeddingPlannerApp.swift
+++ b/SwiftApp/WeddingPlannerApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct WeddingPlannerApp: App {
+    var body: some Scene {
+        WindowGroup {
+            DashboardView()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add standalone SwiftUI app scaffold for a wedding planner
- include models for guests, tasks, and budget items
- provide dashboard, guest list, tasks, and budget views

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689544e06fb08331aa429216e771aa02